### PR TITLE
Make state and cache configurable.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ export type Opts = {
   exporter: string;
   noProgress: boolean;
   monitor: boolean;
+  cache?: Cache;
 };
 
 export const DEFAULT_OPTS: Opts = {
@@ -225,7 +226,7 @@ export class App {
     const exporters = await this.getExporters();
 
     const fetcher = new BattleFetcher({
-      cache: new FileCache(this.state.cacheDir),
+      cache: this.opts.cache ?? new FileCache(this.state.cacheDir),
       state: this.state,
     });
     console.log("Fetching battle list...");


### PR DESCRIPTION
This patch series adds a new `StateBackend` type and make `StateBackend` / `Cache` configurable.

ギャラ (2):
      feat: Allow specify cache in App opts.
      feat: Add StateBackend type.

 src/app.ts   | 18 ++++++++----------
 src/state.ts | 24 ++++++++++++++++++++++++
 2 files changed, 32 insertions(+), 10 deletions(-)