### PR TITLE
fix: RankTracker::getRankStateById (fix #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.33
+
+fix: RankTracker::getRankStateById (fix
+[#36](https://github.com/spacemeowx2/s3si.ts/issues/36))
+
 ## 0.1.32
 
 fix: auto promotion will miss point tracking duration an export

--- a/src/RankTracker.ts
+++ b/src/RankTracker.ts
@@ -251,6 +251,11 @@ export class RankTracker {
 
     let cur = this.state;
     let before = cur;
+
+    // there is no delta for first game
+    if (cur.gameId === gid) {
+      return;
+    }
     while (cur.gameId !== gid) {
       const delta = this.deltaMap.get(cur.gameId);
       if (!delta) {

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,7 +1,7 @@
 import type { StatInkPostBody, VsHistoryDetail } from "./types.ts";
 
 export const AGENT_NAME = "s3si.ts";
-export const S3SI_VERSION = "0.1.32";
+export const S3SI_VERSION = "0.1.33";
 export const NSOAPP_VERSION = "2.3.1";
 export const WEB_VIEW_VERSION = "1.0.0-433ec0e8";
 export const S3SI_LINK = "https://github.com/spacemeowx2/s3si.ts";


### PR DESCRIPTION
It may return the same before and after state.