### PR TITLE
Login Error: Suggested Fix

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,6 @@ export async function readline(
       return line;
     }
   }
-  throw new Error("EOF");
 }
 
 export function urlBase64Encode(data: ArrayBuffer) {


### PR DESCRIPTION
Hi!
When I used s3si.ts for the first time I encountered an "EOF error" while configuring the profile, looking at the code it seems that its thrown each time readLine in utils.ts is called since its at the end of the function body outside any kind of conditional statement.

This PR is an attempt to fix this, it may not be the optimal one since I don't know the codebase very well but I hope that you'll appreciate.

```shell
emiliano@MacBook-Air-di-Emiliano ~> deno run -Ar https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/s3si.ts
Failed to read config file, create new config file. (NotFound: No such file or directory (os error 2): readfile './profile.json')
Navigate to this URL in your browser:
https://accounts.nintendo.com/login?post_login_redirect_uri=https%3A%2F%2Faccounts.nintendo.com%2Fconnect%2F1.0.0%2Fauthorize%3Fstate%3Dmc0ULgtEciX7FE7OC0WvlfJCH6vswekrkYACsrOzsGHQWpCJ%26redirect_uri%3Dnpf71b963c1b7b6d119%253A%252F%252Fauth%26client_id%3D71b963c1b7b6d119%26scope%3Dopenid%2Buser%2Buser.birthday%2Buser.mii%2Buser.screenName%26response_type%3Dsession_token_code%26session_token_code_challenge%3DWqwukmAjliklsT0ndZHt6THNUJBd6jm09AB1K0WODCw%26session_token_code_challenge_method%3DS256%26theme%3Dlogin_form
Log in, right click the "Select this account" button, copy the link address, and paste it below:
npf71b963c1b7b6d119://auth#session_state=e6334f2c5b913052f9235f42781ff885a328a10a4ec13423cebebf6b9a069bf1&session_token_code=eyJhbGciOiJIUzI1NiJ9.eyJzdGM6c2NwIjpbMCw4LDksMTcsMjNdLCJ0eXAiOiJzZXNzaW9uX3Rva2VuX2NvZGUiLCJqdGkiOiI3ODg4NTk3OTQyNSIsInN0YzptIjoiUzI1NiIsImV4cCI6MTY4ODU5MDk0MSwiaWF0IjoxNjg4NTkwMzQxLCJzdWIiOiI4M2E5NTQ3ZjViMjNkMTZiIiwic3RjOmMiOiJXcXd1a21Bamxpa2xzVDBuZFpIdDZUSE5VSkJkNmptMDlBQjFLMFdPREN3IiwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5uaW50ZW5kby5jb20iLCJhdWQiOiI3MWI5NjNjMWI3YjZkMTE5In0.ALz4oJIR9pX5Ia5zvPGCrGmt97k6y9fMkBE4vAB4C8I&state=mc0ULgtEciX7FE7OC0WvlfJCH6vswekrkYACsrOzsGHQWpCJ
stat.ink API key is not set. Please enter below.
Error: EOF
    at readline (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/utils.ts:20:9)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Object.prompt (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/env.ts:47:14)
    at async App.getExporters (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/app.ts:198:22)
    at async App.exportOnce (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/app.ts:258:23)
    at async App.run (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/app.ts:438:7)
    at async showError (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/utils.ts:75:12)
    at async https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/s3si.ts:51:1
error: Uncaught (in promise) Error: EOF
  throw new Error("EOF");
        ^
    at readline (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/utils.ts:20:9)
    at eventLoopTick (ext:core/01_core.js:183:11)
    at async Object.prompt (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/env.ts:47:14)
    at async App.getExporters (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/app.ts:198:22)
    at async App.exportOnce (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/app.ts:258:23)
    at async App.run (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/app.ts:438:7)
    at async showError (https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/src/utils.ts:75:12)
    at async https://raw.githubusercontent.com/spacemeowx2/s3si.ts/main/s3si.ts:51:1
```