### PR TITLE
nxapi Presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
                                  ("vs", "coop")
     --with-summary               Include summary in the output
     --help                       Show this help message and exit
+    --nxapi-presence             Extends monitoring mode to use Nintendo Switch presence from nxapi
 ```
 
 3. If it's your first time running this, follow the instructions to login to

--- a/s3si.ts
+++ b/s3si.ts
@@ -4,7 +4,13 @@ import { flags } from "./deps.ts";
 
 const parseArgs = (args: string[]) => {
   const parsed = flags.parse(args, {
-    string: ["profilePath", "exporter", "skipMode", "listMethod", "nxapiPresenceUrl"],
+    string: [
+      "profilePath",
+      "exporter",
+      "skipMode",
+      "listMethod",
+      "nxapiPresenceUrl",
+    ],
     boolean: ["help", "noProgress", "monitor", "withSummary"],
     alias: {
       "help": "h",
@@ -15,7 +21,7 @@ const parseArgs = (args: string[]) => {
       "skipMode": ["s", "skip-mode"],
       "withSummary": "with-summary",
       "listMethod": "list-method",
-      "nxapiPresenceUrl": ["nxapi-presence"]
+      "nxapiPresenceUrl": ["nxapi-presence"],
     },
   });
   return parsed;

--- a/s3si.ts
+++ b/s3si.ts
@@ -15,7 +15,7 @@ const parseArgs = (args: string[]) => {
       "skipMode": ["s", "skip-mode"],
       "withSummary": "with-summary",
       "listMethod": "list-method",
-      "nxapiPresenceUrl": ["nxapi-presence-url", "nxapi-presence"]
+      "nxapiPresenceUrl": ["nxapi-presence"]
     },
   });
   return parsed;
@@ -41,7 +41,7 @@ Options:
                                  ("vs", "coop")
     --with-summary               Include summary in the output
     --help                       Show this help message and exit
-    --nxapi-presence-url         Extends monitoring mode to use Nintendo Switch presence from nxapi`,
+    --nxapi-presence             Extends monitoring mode to use Nintendo Switch presence from nxapi`,
   );
   Deno.exit(0);
 }

--- a/s3si.ts
+++ b/s3si.ts
@@ -4,7 +4,7 @@ import { flags } from "./deps.ts";
 
 const parseArgs = (args: string[]) => {
   const parsed = flags.parse(args, {
-    string: ["profilePath", "exporter", "skipMode", "listMethod"],
+    string: ["profilePath", "exporter", "skipMode", "listMethod", "nxapiPresenceUrl"],
     boolean: ["help", "noProgress", "monitor", "withSummary"],
     alias: {
       "help": "h",
@@ -15,6 +15,7 @@ const parseArgs = (args: string[]) => {
       "skipMode": ["s", "skip-mode"],
       "withSummary": "with-summary",
       "listMethod": "list-method",
+      "nxapiPresenceUrl": ["nxapi-presence-url", "nxapi-presence"]
     },
   });
   return parsed;
@@ -39,7 +40,8 @@ Options:
     --skip-mode <mode>, -s       Skip mode (default: null)
                                  ("vs", "coop")
     --with-summary               Include summary in the output
-    --help                       Show this help message and exit`,
+    --help                       Show this help message and exit
+    --nxapi-presence-url         Extends monitoring mode to use Nintendo Switch presence from nxapi`,
   );
   Deno.exit(0);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -412,9 +412,14 @@ export class App {
         await this.exportOnce();
       }
       if (isSplatoon3Active !== this.splatoon3PreviouslyActive) {
-        this.env.logger.debug("Splatoon 3 status has changed from", this.splatoon3PreviouslyActive, "to", isSplatoon3Active)
+        this.env.logger.debug(
+          "Splatoon 3 status has changed from",
+          this.splatoon3PreviouslyActive,
+          "to",
+          isSplatoon3Active,
+        );
       }
-      this.splatoon3PreviouslyActive = isSplatoon3Active
+      this.splatoon3PreviouslyActive = isSplatoon3Active;
     }
   }
   async monitor() {

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -116,3 +116,5 @@ export const SPLATNET3_STATINK_MAP: {
     2: "high",
   },
 };
+
+export const SPLATOON3_TITLE_ID = "0100c2500fc20000";


### PR DESCRIPTION
This pull request adds support for pulling presence data from nxapi presence-server endpoints by using the cli flag `--nxapi-presence <nxapi presence url>` where the url is something like https://nxapi-presence.fancy.org.uk/api/presence/11020bdb0448042a. (For context, the hosted nxapi presence-server in the nxapi Discord has 169 users with Splatoon 3, so I believe that this could be a decent way to reduce requests to Nintendo)

The intent of this PR is to make it more comfortable (as in less worried about action from Nintendo) to run s3si.ts in the background 24/7 without constant requests to SplatNet 3 by checking presence information from nxapi. The only requests to Nintendo when not playing is the presence-server account requesting information about friends this way. 

Requests are made to SplatNet 3 when:
- the command is first ran
- every loop when Splatoon 3 is active
- once after Splatoon 3 is no longer active (to catch any battles at the end)