### PR TITLE
fix: update outdated GraphQL query hashes for SplatNet 3 API

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -20,9 +20,9 @@ export enum Queries {
   PrivateBattleHistoriesQuery =
     "fef94f39b9eeac6b2fac4de43bc0442c16a9f2df95f4d367dd8a79d7c5ed5ce7",
   VsHistoryDetailQuery =
-    "20f88b10d0b1d264fcb2163b0866de26bbf6f2b362f397a0258a75b7fa900943",
+    "94faa2ff992222d11ced55e0f349920a82ac50f414ae33c83d1d1c9d8161c5dd",
   CoopHistoryQuery =
-    "0f8c33970a425683bb1bdecca50a0ca4fb3c3641c0b2a1237aedfde9c0cb2b8f",
+    "e11a8cf2c3de7348495dea5cdcaa25e0c153541c4ed63f044b6c174bc5b703df",
   CoopHistoryDetailQuery =
     "f2d55873a9281213ae27edc171e2b19131b3021a2ae263757543cdd3bf015cc8",
   myOutfitCommonDataFilteringConditionQuery =
@@ -30,7 +30,7 @@ export enum Queries {
   myOutfitCommonDataEquipmentsQuery =
     "45a4c343d973864f7bb9e9efac404182be1d48cf2181619505e9b7cd3b56a6e8",
   HistoryRecordQuery =
-    "0a62c0152f27c4218cf6c87523377521c2cff76a4ef0373f2da3300079bf0388",
+    "a654ecc80161a7ca5c38761c1d9e502d405eae764e2d343618b9c74b1dc0a80f",
   ConfigureAnalyticsQuery =
     "2a9302bdd09a13f8b344642d4ed483b9464f20889ac17401e993dfa5c2bb3607",
 }


### PR DESCRIPTION
Outdated graphql query hashes are causing 400 Bad Request errors when fetching data from SplatNet 3 API.

This PR updates the latest graphql hash values, based on https://github.com/nintendoapis/nintendo-app-versions/blob/main/data/splatnet3-app.json and https://github.com/samuelthomas2774/nxapi/discussions/11.

Tested and s3si.ts works again.